### PR TITLE
don't confuse act year and number

### DIFF
--- a/docpipe/citations.py
+++ b/docpipe/citations.py
@@ -46,7 +46,7 @@ class ActMatcher(CitationMatcher):
     """
     pattern_re = re.compile(
         r"""\bAct,?\s*
-            (\d{2,4}\s*)?
+            ((19|20)\d{2}\s*)?
             \(?
             (?P<ref>
               ([no\.]*\s*)?

--- a/docpipe/tests/test_matchers.py
+++ b/docpipe/tests/test_matchers.py
@@ -257,8 +257,8 @@ class RefsActMatcherTest(TestCase):
         text = """
   Recalling Act 25 of 2020, the Need to Prepare
   Recalling Income Tax Act, 1962 (No 58 of 1962) on the Composition and Operationalization
-  Recalling Act 125 of 2021, the Need to Prepare
-  Recalling Act no. 225 of 2021, the Need to Prepare
+  Recalling Act 195 of 2021, the Need to Prepare
+  Recalling Act no. 205 of 2021, the Need to Prepare
   Recalling Act no. 1 of 2021, the Need to Prepare
 """
         self.marker.extract_text_matches(self.frbr_uri, text)
@@ -276,12 +276,12 @@ class RefsActMatcherTest(TestCase):
                     ' on the Composition and Operat',
                 ),
                 ExtractedCitation(
-                    "Act 125 of 2021", 152, 167, "/akn/za/act/2021/125", 0,
+                    "Act 195 of 2021", 152, 167, "/akn/za/act/2021/195", 0,
                     'perationalization\n  Recalling ',
                     ', the Need to Prepare\n  Recall',
                 ),
                 ExtractedCitation(
-                    "Act no. 225 of 2021", 201, 220, "/akn/za/act/2021/225", 0,
+                    "Act no. 205 of 2021", 201, 220, "/akn/za/act/2021/205", 0,
                     'e Need to Prepare\n  Recalling ',
                     ', the Need to Prepare\n  Recall',
                 ),

--- a/docpipe/tests/test_matchers.py
+++ b/docpipe/tests/test_matchers.py
@@ -260,6 +260,10 @@ class RefsActMatcherTest(TestCase):
   Recalling Act 195 of 2021, the Need to Prepare
   Recalling Act no. 205 of 2021, the Need to Prepare
   Recalling Act no. 1 of 2021, the Need to Prepare
+  Recalling Act no. 1994 of 2021, the Need to Prepare
+  Recalling Act 1994 of 2021, the Need to Prepare
+  Recalling Act no. 2022 of 2021, the Need to Prepare
+  Recalling Act 2022 of 2021, the Need to Prepare
 """
         self.marker.extract_text_matches(self.frbr_uri, text)
 
@@ -287,6 +291,26 @@ class RefsActMatcherTest(TestCase):
                 ),
                 ExtractedCitation(
                     "Act no. 1 of 2021", 254, 271, "/akn/za/act/2021/1", 0,
+                    'e Need to Prepare\n  Recalling ',
+                    ', the Need to Prepare\n  Recall',
+                ),
+                ExtractedCitation(
+                    "Act no. 1994 of 2021", 305, 325, "/akn/za/act/2021/1994", 0,
+                    'e Need to Prepare\n  Recalling ',
+                    ', the Need to Prepare\n  Recall',
+                ),
+                ExtractedCitation(
+                    "Act 1994 of 2021", 359, 375, "/akn/za/act/2021/1994", 0,
+                    'e Need to Prepare\n  Recalling ',
+                    ', the Need to Prepare\n  Recall',
+                ),
+                ExtractedCitation(
+                    "Act no. 2022 of 2021", 409, 429, "/akn/za/act/2021/2022", 0,
+                    'e Need to Prepare\n  Recalling ',
+                    ', the Need to Prepare\n  Recall',
+                ),
+                ExtractedCitation(
+                    "Act 2022 of 2021", 463, 479, "/akn/za/act/2021/2022", 0,
                     'e Need to Prepare\n  Recalling ',
                     ', the Need to Prepare\n',
                 ),

--- a/docpipe/tests/test_matchers.py
+++ b/docpipe/tests/test_matchers.py
@@ -257,28 +257,38 @@ class RefsActMatcherTest(TestCase):
         text = """
   Recalling Act 25 of 2020, the Need to Prepare
   Recalling Income Tax Act, 1962 (No 58 of 1962) on the Composition and Operationalization
+  Recalling Act 125 of 2021, the Need to Prepare
+  Recalling Act no. 225 of 2021, the Need to Prepare
+  Recalling Act no. 1 of 2021, the Need to Prepare
 """
         self.marker.extract_text_matches(self.frbr_uri, text)
 
         self.assertEqual(
             [
                 ExtractedCitation(
-                    "Act 25 of 2020",
-                    13,
-                    27,
-                    "/akn/za/act/2020/25",
-                    0,
+                    "Act 25 of 2020", 13, 27, "/akn/za/act/2020/25", 0,
                     '\n  Recalling ',
                     ', the Need to Prepare\n  Recall',
                 ),
                 ExtractedCitation(
-                    "Act, 1962 (No 58 of 1962)",
-                    72,
-                    97,
-                    "/akn/za/act/1962/58",
-                    0,
+                    "Act, 1962 (No 58 of 1962)", 72, 97, "/akn/za/act/1962/58", 0,
                     'repare\n  Recalling Income Tax ',
                     ' on the Composition and Operat',
+                ),
+                ExtractedCitation(
+                    "Act 125 of 2021", 152, 167, "/akn/za/act/2021/125", 0,
+                    'perationalization\n  Recalling ',
+                    ', the Need to Prepare\n  Recall',
+                ),
+                ExtractedCitation(
+                    "Act no. 225 of 2021", 201, 220, "/akn/za/act/2021/225", 0,
+                    'e Need to Prepare\n  Recalling ',
+                    ', the Need to Prepare\n  Recall',
+                ),
+                ExtractedCitation(
+                    "Act no. 1 of 2021", 254, 271, "/akn/za/act/2021/1", 0,
+                    'e Need to Prepare\n  Recalling ',
+                    ', the Need to Prepare\n',
                 ),
             ],
             self.marker.citations,


### PR DESCRIPTION
This fixes incorrect number extraction for, in particular, 3-digit act numbers like "Act 110 of 2020".