### PR TITLE
Allow None and no href during matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpipe"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name="Greg Kempe", email="greg@laws.africa" },
 ]


### PR DESCRIPTION
This makes it easier for subclasses to opt-out of a match