### PR TITLE
matchers can adjust matched text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpipe"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name="Greg Kempe", email="greg@laws.africa" },
 ]


### PR DESCRIPTION
This makes it possible for a matcher to markup a reference that is only part of a regex