### PR TITLE
Act year number citation matcher

### DIFF
--- a/docpipe/citations.py
+++ b/docpipe/citations.py
@@ -39,7 +39,7 @@ class AchprResolutionMatcher(CitationMatcher):
         return args
 
 
-class ActMatcher(CitationMatcher):
+class ActNoOfYearMatcher(CitationMatcher):
     """ Finds references to Acts in documents, of the form:
     Act 5 of 2019
     Act No. 3 of 92
@@ -76,3 +76,28 @@ class ActMatcher(CitationMatcher):
             em.text = em.text[:-1]
             em.end -= 1
         return em
+
+
+# legacy name for backwards compatibility
+ActMatcher = ActNoOfYearMatcher
+
+
+class ActYearNumberMatcher(ActNoOfYearMatcher):
+    """Finds references to Acts of the form:
+
+    - Foo Act, 1999 (Act 123)
+    """
+    pattern_re = re.compile(r"((?P<year>\d{4})\s*)?\(\s*(?P<ref>Act\s*(?P<num>\d+)\s*)\)", re.I)
+
+    def make_extracted_match(self, match: Match) -> ExtractedMatch:
+        match = super().make_extracted_match(match)
+        # adjust the match so that it only covers the "ref" group
+        match.text = match.groups["ref"]
+        match.start = match.original_match.start("ref")
+        match.end = match.original_match.end("ref")
+        return match
+
+    def make_href(self, match: ExtractedMatch):
+        year = match.groups["year"]
+        num = match.groups["num"]
+        return f"/akn/gh/act/{year}/{num}"

--- a/docpipe/tests/test_matchers.py
+++ b/docpipe/tests/test_matchers.py
@@ -5,7 +5,7 @@ import lxml.html
 from lxml import etree
 from cobalt import FrbrUri
 
-from docpipe.citations import AchprResolutionMatcher, ActMatcher
+from docpipe.citations import AchprResolutionMatcher, ActNoOfYearMatcher, ActYearNumberMatcher
 from docpipe.matchers import ExtractedCitation
 
 
@@ -147,11 +147,11 @@ class RefsAchprResolutionMatcherTest(TestCase):
         )
 
 
-class RefsActMatcherTest(TestCase):
+class RefsActNoOfYearMatcherTest(TestCase):
     maxDiff = None
 
     def setUp(self):
-        self.marker = ActMatcher()
+        self.marker = ActNoOfYearMatcher()
         self.frbr_uri = FrbrUri.parse("/akn/za-wc/act/2021/509")
 
     def test_html_matches(self):
@@ -365,6 +365,102 @@ class RefsActMatcherTest(TestCase):
                     "Act 2022 of 2021", 463, 479, "/akn/za/act/2021/2022", 0,
                     'e Need to Prepare\n  Recalling ',
                     ', the Need to Prepare\n  Avoid ',
+                ),
+            ],
+            self.marker.citations,
+        )
+
+
+class ActYearNumberTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.marker = ActYearNumberMatcher()
+        self.frbr_uri = FrbrUri.parse("/akn/za-wc/act/2021/509")
+
+    def test_html_matches(self):
+        html = lxml.html.fromstring(
+            """
+<div>
+  <p>No markup inside existing Act, 1990 (<a href="#foo">Act 123</a>) A tags.</p>
+  <p>National Environment Management: Air Quality Act, 1990 (Act 123);</p>
+</div>
+"""
+        )
+        self.marker.markup_html_matches(self.frbr_uri, html)
+
+        self.assertMultiLineEqual(
+            """<div>
+  <p>No markup inside existing Act, 1990 (<a href="#foo">Act 123</a>) A tags.</p>
+  <p>National Environment Management: Air Quality Act, 1990 (<a href="/akn/gh/act/1990/123">Act 123</a>);</p>
+</div>""",
+            lxml.html.tostring(html, encoding="unicode", pretty_print=True).strip(),
+        )
+        self.assertEqual(
+            [
+                ExtractedCitation(
+                    "Act 123",
+                    56,
+                    63,
+                    "/akn/gh/act/1990/123",
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+            self.marker.citations,
+        )
+
+    def test_xml_matches(self):
+        xml = etree.fromstring(
+            """<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+  <statement name="statement">
+    <preamble>
+      <p eId="preamble__p_2">No markup inside existing Act, 1990 (<ref href="#foo">Act 123</ref>) ref tags.</p>
+      <p eId="preamble__p_4">National Environment Management: Air Quality Act, 1990 (Act 123);</p>
+    </preamble>
+  </statement>
+</akomaNtoso>"""
+        )
+        self.marker.markup_xml_matches(self.frbr_uri, xml)
+
+        self.assertMultiLineEqual("""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+  <statement name="statement">
+    <preamble>
+      <p eId="preamble__p_2">No markup inside existing Act, 1990 (<ref href="#foo">Act 123</ref>) ref tags.</p>
+      <p eId="preamble__p_4">National Environment Management: Air Quality Act, 1990 (<ref href="/akn/gh/act/1990/123">Act 123</ref>);</p>
+    </preamble>
+  </statement>
+</akomaNtoso>""",
+                                  etree.tostring(xml, encoding="unicode", pretty_print=True).strip(),
+                                  )
+        self.assertEqual(
+            [
+                ExtractedCitation(
+                    "Act 123",
+                    56,
+                    63,
+                    "/akn/gh/act/1990/123",
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+            self.marker.citations,
+        )
+
+    def test_text_matches(self):
+        text = """
+  National Environment Management: Air Quality Act, 1990 (Act 123)
+"""
+        self.marker.extract_text_matches(self.frbr_uri, text)
+
+        self.assertEqual(
+            [
+                ExtractedCitation(
+                    "Act 123", 59, 66, "/akn/gh/act/1990/123", 0,
+                    'ement: Air Quality Act, 1990 (',
+                    ')\n'
                 ),
             ],
             self.marker.citations,


### PR DESCRIPTION
This matches Act citations of the form "Foo Act, 1992 (Act 2)" which we don't currently match, and which are heavily used in Ghana.